### PR TITLE
Fix Overflow

### DIFF
--- a/fast-courses-app/src/App.css
+++ b/fast-courses-app/src/App.css
@@ -40,7 +40,7 @@
   outline: none;
   width: 90%;
   max-height: 100%;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .modal__basic__overlay {
@@ -141,7 +141,7 @@ body.scrolled .sticky {
   position: sticky;
   top: 0;
   height: calc(100vh - 2rem);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .search-panel__results {
@@ -501,13 +501,13 @@ a.ais-Menu-link.plan-button.planned, a.ais-Menu-link.plan-button:hover {
 .hit__reviews__right {
   padding-top: 0.5rem;
   max-height: 195px;
-  overflow-y: scroll;
+  overflow-y: auto;
   flex: 1;
 }
 
 .hit__reviews__list {
   max-height: 150px;
-  overflow-y: scroll;
+  overflow-y: auto;
   padding: 0.33rem 0;
 }
 


### PR DESCRIPTION
Overflow scroll always places the scroll bar even when it's not needed. I believe mac X chrome works around this and doesn't show it, but for windows it's annoying :(. Changing to auto fixes this to only show when necessary (https://www.w3schools.com/cssref/pr_pos_overflow.asp).

Issues:
![image](https://user-images.githubusercontent.com/17102158/90804141-cd6cbe00-e2e7-11ea-8429-8589fadaca0c.png)
![image](https://user-images.githubusercontent.com/17102158/90804195-dfe6f780-e2e7-11ea-910b-3b4c3d3bea38.png)
